### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Django Outbox
 
 ![Downloads](https://img.shields.io/pypi/dm/django-outbox.svg?style=flat)
 [![Code Health](https://landscape.io/github/poiati/django-outbox/master/landscape.svg?style=flat)](https://landscape.io/github/poiati/django-outbox/master)
-![Versions](https://pypip.in/py_versions/django-outbox/badge.svg?style=flat)
+![Versions](https://img.shields.io/pypi/pyversions/django-outbox.svg?style=flat)
 
 Capture all mails sent and show it in a simple web interface.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-outbox))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-outbox`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.